### PR TITLE
🔧 fix: 동화책 생성 후 수정페이지에서 발생하는 다양한 에러 해결

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -27,6 +27,7 @@ function App() {
   const coverUrl = useSelector((state) => state.book.coverUrl);
   const pages = useSelector((state) => state.book.pages);
   const length = useSelector((state) => state.book.length);
+  const prevLength = useSelector((state) => state.book.prevLength);
   const imageCnt = useSelector((state) => state.book.imageCnt);
   const saved = useSelector((state) => state.book.saved);
 
@@ -34,7 +35,13 @@ function App() {
   useEffect(() => {
     async function saveBook() {
       //동화책이 완성됐지만 아직 저장되지 않았다면
-      if (title && length !== 0 && coverUrl && imageCnt === length && !saved) {
+      if (
+        title &&
+        length !== 0 &&
+        coverUrl &&
+        imageCnt === prevLength &&
+        !saved
+      ) {
         //바디 가공
         const body = {
           diaryId: diaryId,
@@ -42,7 +49,7 @@ function App() {
           genre: genre,
           coverUrl: coverUrl,
           date: date,
-          pages: pages.slice(0, length),
+          pages: pages.slice(0, prevLength),
         };
         console.log(body);
         const bookData = await postBook(body); //최초 동화책 저장

--- a/src/components/book_edit/SequelPage.js
+++ b/src/components/book_edit/SequelPage.js
@@ -29,6 +29,7 @@ const Root = styled.div`
   position: relative;
   width: 100%;
   height: ${(props) => !props.$show && "0px"};
+  margin-bottom: ${(props) => (!props.$show ? "0px" : "46px")};
   overflow: hidden;
 `;
 

--- a/src/pages/BookEditPage.js
+++ b/src/pages/BookEditPage.js
@@ -66,7 +66,7 @@ const BookEditPage = () => {
           x: positions[index + 1].x,
           y: positions[index + 1].y,
         }))
-        .slice(0, length),
+        .slice(0, prevLength),
     };
     console.log("동화책 1개 수정 api 요청 바디", body);
     await editBook(bookId, body);
@@ -165,13 +165,14 @@ const BookEditPage = () => {
         <ArrowButton
           onClick={onRightClick}
           side="right"
-          hide={pageNum !== 0 && pageNum >= pages.length - 1}
+          hide={pageNum !== 0 && pageNum >= length - 1}
         />
       </Container>
       <Submit
         type="submit"
         onClick={handleEditBook}
         disabled={!saved}
+        $disabled={!saved}
         $background={colors.theme1}
       >
         완성하기
@@ -225,9 +226,10 @@ const Submit = styled.button`
   border: none;
   border-radius: 30px;
   color: white;
-  background: ${({ $background }) => $background};
+  background: ${({ $background, $disabled }) =>
+    $disabled ? "grey" : $background};
   &:hover {
-    cursor: pointer;
+    cursor: ${({ $disabled }) => ($disabled ? "default" : "pointer")};
   }
   position: fixed;
   bottom: 20px;

--- a/src/pages/DiaryForm.js
+++ b/src/pages/DiaryForm.js
@@ -109,12 +109,14 @@ const DiaryForm = () => {
           );
         }
 
-        //수정페이지로 리다이렉션
-        navigate(`/book-edit`);
+        dispatch(bookSlice.actions.setPrevLength(length)); //기존 길이 저장
+        dispatch(bookSlice.actions.addPage()); //뒷이야기 생성할 빈페이지 추가
+
+        navigate(`/book-edit`); //수정페이지로 리다이렉션
       }
     }
     createBook();
-  }, [title, pages, length, coverUrl, imageCnt, dispatch, navigate]);
+  }, [title]);
 
   //날짜 포맷팅 함수
   const dateToString = (date) => {

--- a/src/redux/bookSlice.js
+++ b/src/redux/bookSlice.js
@@ -54,7 +54,7 @@ export const bookSlice = createSlice({
       state.coverUrl = "";
       state.pages = Array.from({ length: 15 }, () => ({
         text: "",
-        imgUrl: "",
+        imgUrl: "null",
         x: 0,
         y: 0,
       }));
@@ -122,6 +122,7 @@ export const bookSlice = createSlice({
       state.title = action.payload.title;
       action.payload.texts.forEach((text, index) => {
         state.pages[index].text = text;
+        state.pages[index].imgUrl = "";
       });
       state.length = action.payload.texts.length;
     });


### PR DESCRIPTION
맨 마지막 페이지가 보이지 않다가, 뒷이야기 이어쓰기 버튼을 누르면 보이는 에러 해결
동화 수정 api 요청은 최초 저장된 동화책 길이와 똑같게 보내도록
뒷이야기 이어쓰기 api 요청은 기존 페이지 말고 추가된 페이지들만 보내도록
맨 마지막 페이지에서 오른쪽 버튼 숨기기
뒷이야기 이어쓰기 버튼 눌렀을 때 로딩 아이콘 안뜨게
뒷이야기 이어쓰기 위치가 살짝 아래로 내려가 있는거 고치기
최초동화책 저장 전에는 버튼 회색으로